### PR TITLE
Update links to Codes of Conduct

### DIFF
--- a/inst/pkgdown/_pkgdown.yml
+++ b/inst/pkgdown/_pkgdown.yml
@@ -25,6 +25,6 @@ home:
       coc:
         title: Code of Conduct
         text: |
-          [Código de Conducta](https://docs.google.com/document/d/e/2PACX-1vSi9qlNRvh6nSSlHEcM8mpB9XQHDQyo2I12VG--r5SwciJ5UdRzhUp3sYXJhXoyYg/pub)
+          [Código de Conducta](https://github.com/epiverse-trace/.github/blob/main/CODE_OF_CONDUCT_es.md)
 
-          [Code of Conduct](https://docs.google.com/document/u/1/d/e/2PACX-1vRcwl2uaKdEQT5iS-9MroDMKsd81oR8v1gdlY1kHTTjgGEbLKfcWxtdrkvVRhJJGQalsgC1A4K4YiDe/pub)
+          [Code of Conduct](https://github.com/epiverse-trace/.github/blob/main/CODE_OF_CONDUCT_en.md)


### PR DESCRIPTION
This PR updates the links to the Codes of Conduct based on the latest changes.

@Bisaloo requested this change in https://github.com/epiverse-trace/.github/pull/27#issuecomment-2009647109
