### PR TITLE
Leverage new navbar-bg var

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,12 @@
 Package: epiversetheme
 Title: A 'pkgdown' Template for 'Epiverse-TRACE' Packages
 Version: 0.1.0
-Authors@R: 
+Authors@R:
     person("Hugo", "Gruson", , "hugo.gruson+R@normalesup.org", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0002-4094-1476"))
 Description: What the package does (one paragraph).
 Imports:
-    pkgdown (>= 2.1.0)
+    pkgdown (>= 2.1.1.9000)
 License: MIT
 Config/testthat/edition: 3
 Encoding: UTF-8

--- a/inst/pkgdown/_pkgdown.yml
+++ b/inst/pkgdown/_pkgdown.yml
@@ -13,6 +13,7 @@ template:
         gtag('config', 'G-XZ471458FQ');
       </script>
   bslib:
+    navbar-bg: "#071E2D"
     base_font: "DM Sans"
     code_font: "Roboto Mono"
     danger: "#F04A4C"

--- a/inst/pkgdown/extra.scss
+++ b/inst/pkgdown/extra.scss
@@ -1,9 +1,5 @@
 @import 'https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,700&family=Roboto+Mono&display=swap';
 
-.navbar {
-  background-color: #071E2D;
-}
-
 .navbar-nav .nav-item > .nav-link, .navbar-brand, .navbar-brand:hover, .navbar-brand:focus {
   color: #fff;
 }


### PR DESCRIPTION
Blocked until pkgdown 2.2.0 is released to avoid relying on pkgdown dev version.
